### PR TITLE
sns45: assign to lschuermann

### DIFF
--- a/machines/sns45.nix
+++ b/machines/sns45.nix
@@ -1,3 +1,5 @@
+# Configured as a workstation for @lschuermann
+
 { config, pkgs, ... }:
 
 let
@@ -12,9 +14,22 @@ in {
   # List packages installed in system profile. To search, run:
   # $ nix search wget
   environment.systemPackages = with pkgs; [
+    wget vim htop tmux nload iftop dnsutils gitAndTools.gitFull gnupg
+    gitAndTools.git-annex mtr bc zip unzip nmap nix-prefetch-git pdftk
+    imagemagick ghostscript rclone
   ];
 
   programs.mosh.enable = true;
 
   users.mutableUsers = false;
+
+  users.users.leons = {
+    isNormalUser = true;
+    extraGroups = [ "wheel" ];
+    openssh.authorizedKeys.keys = utils.githubSSHKeys "lschuermann";
+  };
+
+  users.users.root.openssh.authorizedKeys.keys = [
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOD4XspKe2E5BhBmx+GtRHdRR72+Q7wC7nFHbDj1VVzJ lschuermann/silicon/sns-nixbuild"
+  ];
 }

--- a/machines/sns45.nix
+++ b/machines/sns45.nix
@@ -1,6 +1,3 @@
-# Configured as a workstation for @cyu
-# Can be taken back at the end of Spring '22 semester (note from 04/08/2022)
-
 { config, pkgs, ... }:
 
 let
@@ -20,10 +17,4 @@ in {
   programs.mosh.enable = true;
 
   users.mutableUsers = false;
-
-  users.users.cyu = {
-    isNormalUser = true;
-    extraGroups = [ "wheel" ];
-    openssh.authorizedKeys.keys = utils.githubSSHKeys "cyu6";
-  };
 }


### PR DESCRIPTION
Configures the host sns45 as a workstation for @lschuermann. Adds a selection of system packages. Furthermore, adds a root SSH key to allow for using the host as a Nix remote builder, while not having manage Nix derivation signing keys and trusting keys of the machines issuing remote builds

These changes have been tested in a VM by running `test/test.sh` and validating that build & login (as both root and user) work.