### PR TITLE
Add matrix-synapse patch to use OIT aliases

### DIFF
--- a/machines/adam.nix
+++ b/machines/adam.nix
@@ -95,7 +95,7 @@ let
 in {
 
   # Import common configurat for all machines (locale, SSHd, updates...)
-  imports = [ deplorable common ./matrix.nix ];
+  imports = [ deplorable common ../utils/matrix.nix ];
 
   # List packages installed in system profile. To search, run:
   # $ nix search wget

--- a/utils/matrix-synapse-localpart.patch
+++ b/utils/matrix-synapse-localpart.patch
@@ -1,0 +1,41 @@
+From 6bf63c748019c8cb7d02db4082b845313b3b6c0b Mon Sep 17 00:00:00 2001
+From: Leon Schuermann <leon@is.currently.online>
+Date: Wed, 14 Sep 2022 18:00:05 -0400
+Subject: [PATCH] handlers/cas.py: determine localpart from alt "campusid"
+
+This causes synapse to determine the localpart of users using the last
+string contained in the "campusid" attribute list, if available in the
+CAS response. In practice, this will use a user's email alias, if one
+has been assigned.
+
+Synapse persists mappings from CAS usernames to aliases automatically in
+a table called "user_external_ids". Hence future availability of this
+value will not impact any existing registered users, and the system
+performs fallback onto the NetID in case of a missing or invalid
+"campusid" attribute.
+---
+ synapse/handlers/cas.py | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/synapse/handlers/cas.py b/synapse/handlers/cas.py
+index 7163af800..32d77edfd 100644
+--- a/synapse/handlers/cas.py
++++ b/synapse/handlers/cas.py
+@@ -344,7 +344,11 @@ class CasHandler:
+                 to redirect to an interstitial page.
+         """
+         # Note that CAS does not support a mapping provider, so the logic is hard-coded.
+-        localpart = map_username_to_mxid_localpart(cas_response.username)
++        if "campusid" in cas_response.attributes \
++           and type(cas_response.attributes["campusid"]) == list:
++            localpart = map_username_to_mxid_localpart(next(filter(lambda cid: type(cid) == str and cid != cas_response.username, cas_response.attributes["campusid"]), cas_response.username))
++        else:
++            localpart = map_username_to_mxid_localpart(cas_response.username)
+ 
+         async def cas_response_to_user_attributes(failures: int) -> UserAttributes:
+             """
+
+base-commit: 6f80fe1e1bbb6cab3ce605b2023e0488e2d80d52
+-- 
+2.36.2
+

--- a/utils/matrix.nix
+++ b/utils/matrix.nix
@@ -85,6 +85,9 @@ in {
 
   services.matrix-synapse = {
     enable = true;
+    package = pkgs.matrix-synapse.overrideDerivation (oldAttrs: {
+      patches = [./matrix-synapse-localpart.patch];
+    });
     settings = {
       #federation_domain_whitelist = [ "matrix.org" "mozilla.org" "nixos.org" "is.currently.online" ];
       server_name = "princeton.systems";


### PR DESCRIPTION
Add a (slightly modified) patch from @lschuermann to the `matrix-synapse` package to use alias for MXIDs instead of NetID when available from the OIT CAS login.

This will look for a non-NetID alias in the `campusids` field of the CAS response and use the first one if available during registration. Otherwise will fall-back to netids.