### PR TITLE
Add Noise eval user to all SNS machines temporarily

### DIFF
--- a/machines/sns17.nix
+++ b/machines/sns17.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ config, pkgs, lib, ... }:
 
 let
   hostname = "sns17";
@@ -23,5 +23,21 @@ in {
     isNormalUser = true;
     extraGroups = [ "wheel" ];
     openssh.authorizedKeys.keys = utils.githubSSHKeys "alevy";
+  };
+
+  users.users.noiseeval = {
+    isNormalUser = true;
+    extraGroups = [ "wheel" ];
+    openssh.authorizedKeys.keys = (
+      lib.flatten (
+        builtins.map utils.githubSSHKeys [
+          "alevy"
+          "lschuermann"
+          "leochanj105"
+        ]
+      )
+    ) ++ [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIBrOyN+OmWSv0/RYd7jK+TKx4tMO5Fuz8wyaMUR+j6A noise-eval-peer-key"
+    ];
   };
 }

--- a/machines/sns20.nix
+++ b/machines/sns20.nix
@@ -24,4 +24,20 @@ in {
     extraGroups = [ "wheel" ];
     openssh.authorizedKeys.keys = utils.githubSSHKeys "alevy";
   };
+
+  users.users.noiseeval = {
+    isNormalUser = true;
+    extraGroups = [ "wheel" ];
+    openssh.authorizedKeys.keys = (
+      lib.flatten (
+        builtins.map utils.githubSSHKeys [
+          "alevy"
+          "lschuermann"
+          "leochanj105"
+        ]
+      )
+    ) ++ [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIBrOyN+OmWSv0/RYd7jK+TKx4tMO5Fuz8wyaMUR+j6A noise-eval-peer-key"
+    ];
+  };
 }

--- a/machines/sns21.nix
+++ b/machines/sns21.nix
@@ -24,4 +24,20 @@ in {
     extraGroups = [ "wheel" ];
     openssh.authorizedKeys.keys = utils.githubSSHKeys "alevy";
   };
+
+  users.users.noiseeval = {
+    isNormalUser = true;
+    extraGroups = [ "wheel" ];
+    openssh.authorizedKeys.keys = (
+      lib.flatten (
+        builtins.map utils.githubSSHKeys [
+          "alevy"
+          "lschuermann"
+          "leochanj105"
+        ]
+      )
+    ) ++ [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIBrOyN+OmWSv0/RYd7jK+TKx4tMO5Fuz8wyaMUR+j6A noise-eval-peer-key"
+    ];
+  };
 }

--- a/machines/sns24.nix
+++ b/machines/sns24.nix
@@ -24,4 +24,20 @@ in {
     extraGroups = [ "wheel" ];
     openssh.authorizedKeys.keys = utils.githubSSHKeys "alevy";
   };
+
+  users.users.noiseeval = {
+    isNormalUser = true;
+    extraGroups = [ "wheel" ];
+    openssh.authorizedKeys.keys = (
+      lib.flatten (
+        builtins.map utils.githubSSHKeys [
+          "alevy"
+          "lschuermann"
+          "leochanj105"
+        ]
+      )
+    ) ++ [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIBrOyN+OmWSv0/RYd7jK+TKx4tMO5Fuz8wyaMUR+j6A noise-eval-peer-key"
+    ];
+  };
 }

--- a/machines/sns26.nix
+++ b/machines/sns26.nix
@@ -29,4 +29,20 @@ in {
     extraGroups = [ "wheel" ];
     openssh.authorizedKeys.keys = utils.githubSSHKeys "nataliepopescu";
   };
+
+  users.users.noiseeval = {
+    isNormalUser = true;
+    extraGroups = [ "wheel" ];
+    openssh.authorizedKeys.keys = (
+      lib.flatten (
+        builtins.map utils.githubSSHKeys [
+          "alevy"
+          "lschuermann"
+          "leochanj105"
+        ]
+      )
+    ) ++ [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIBrOyN+OmWSv0/RYd7jK+TKx4tMO5Fuz8wyaMUR+j6A noise-eval-peer-key"
+    ];
+  };
 }

--- a/machines/sns29.nix
+++ b/machines/sns29.nix
@@ -39,4 +39,20 @@ in {
     extraGroups = [ "snapfaas" ];
     openssh.authorizedKeys.keys = utils.githubSSHKeys "kw1122";
   };
+
+  users.users.noiseeval = {
+    isNormalUser = true;
+    extraGroups = [ "wheel" ];
+    openssh.authorizedKeys.keys = (
+      lib.flatten (
+        builtins.map utils.githubSSHKeys [
+          "alevy"
+          "lschuermann"
+          "leochanj105"
+        ]
+      )
+    ) ++ [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIBrOyN+OmWSv0/RYd7jK+TKx4tMO5Fuz8wyaMUR+j6A noise-eval-peer-key"
+    ];
+  };
 }

--- a/machines/sns31.nix
+++ b/machines/sns31.nix
@@ -36,4 +36,20 @@ in {
     extraGroups = [ "wheel" ];
     openssh.authorizedKeys.keys = utils.githubSSHKeys "ashwiniraina";
   };
+
+  users.users.noiseeval = {
+    isNormalUser = true;
+    extraGroups = [ "wheel" ];
+    openssh.authorizedKeys.keys = (
+      lib.flatten (
+        builtins.map utils.githubSSHKeys [
+          "alevy"
+          "lschuermann"
+          "leochanj105"
+        ]
+      )
+    ) ++ [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIBrOyN+OmWSv0/RYd7jK+TKx4tMO5Fuz8wyaMUR+j6A noise-eval-peer-key"
+    ];
+  };
 }

--- a/machines/sns32.nix
+++ b/machines/sns32.nix
@@ -24,4 +24,20 @@ in {
     extraGroups = [ "wheel" ];
     openssh.authorizedKeys.keys = utils.githubSSHKeys "scaspin";
   };
+
+  users.users.noiseeval = {
+    isNormalUser = true;
+    extraGroups = [ "wheel" ];
+    openssh.authorizedKeys.keys = (
+      lib.flatten (
+        builtins.map utils.githubSSHKeys [
+          "alevy"
+          "lschuermann"
+          "leochanj105"
+        ]
+      )
+    ) ++ [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIBrOyN+OmWSv0/RYd7jK+TKx4tMO5Fuz8wyaMUR+j6A noise-eval-peer-key"
+    ];
+  };
 }

--- a/machines/sns33.nix
+++ b/machines/sns33.nix
@@ -35,4 +35,20 @@ in {
     extraGroups = [ "wheel" "docker" ];
     openssh.authorizedKeys.keys = utils.githubSSHKeys "leochanj105";
   };
+
+  users.users.noiseeval = {
+    isNormalUser = true;
+    extraGroups = [ "wheel" ];
+    openssh.authorizedKeys.keys = (
+      lib.flatten (
+        builtins.map utils.githubSSHKeys [
+          "alevy"
+          "lschuermann"
+          "leochanj105"
+        ]
+      )
+    ) ++ [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIBrOyN+OmWSv0/RYd7jK+TKx4tMO5Fuz8wyaMUR+j6A noise-eval-peer-key"
+    ];
+  };
 }

--- a/machines/sns44.nix
+++ b/machines/sns44.nix
@@ -69,4 +69,20 @@ in {
     extraGroups = [ "wheel" "kvm" "docker" ];
     openssh.authorizedKeys.keys = utils.githubSSHKeys "ATLi2001";
   };
+
+  users.users.noiseeval = {
+    isNormalUser = true;
+    extraGroups = [ "wheel" ];
+    openssh.authorizedKeys.keys = (
+      lib.flatten (
+        builtins.map utils.githubSSHKeys [
+          "alevy"
+          "lschuermann"
+          "leochanj105"
+        ]
+      )
+    ) ++ [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIBrOyN+OmWSv0/RYd7jK+TKx4tMO5Fuz8wyaMUR+j6A noise-eval-peer-key"
+    ];
+  };
 }

--- a/machines/sns45.nix
+++ b/machines/sns45.nix
@@ -42,4 +42,20 @@ in {
   users.users.root.openssh.authorizedKeys.keys = [
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOD4XspKe2E5BhBmx+GtRHdRR72+Q7wC7nFHbDj1VVzJ lschuermann/silicon/sns-nixbuild"
   ];
+
+  users.users.noiseeval = {
+    isNormalUser = true;
+    extraGroups = [ "wheel" ];
+    openssh.authorizedKeys.keys = (
+      lib.flatten (
+        builtins.map utils.githubSSHKeys [
+          "alevy"
+          "lschuermann"
+          "leochanj105"
+        ]
+      )
+    ) ++ [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIBrOyN+OmWSv0/RYd7jK+TKx4tMO5Fuz8wyaMUR+j6A noise-eval-peer-key"
+    ];
+  };
 }

--- a/machines/sns49.nix
+++ b/machines/sns49.nix
@@ -26,4 +26,20 @@ in {
     openssh.authorizedKeys.keys = [ "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC9XMuiS7A+rQq2Q7/wIwqFCdbBEI0vXEoLU0DCwPl1KAfvdMM1w46y6+WAv66NMgjDa9wcwjdTBugMdMvWfm6UnEV7XIEbYtK9C9NO4/2gYMcIuMU2KHhoMJ86CIKGrwTDvvmvnFuPdrtIrhH66fg2qPMMUPhlQ93KlFsD+bKdQaKIIewLQaPgECuR/wb8a5qmmpAGdGLMGu+RXVJO71kiPdO999V0g1+pBA1FOqkuUUiE7nYQQfZl5PiaiqnI4PeR5qV1HWOkpNESfdzkrMXG/aa9/sOjl/q3DK6kmAIy0iaqm4V7SWWSz7WCQIXAWfFORdbpMaCtDaRPMShzQY6F linanqinqin@linanqinqindeMacBook-Pro.local
 " ];
   };
+
+  users.users.noiseeval = {
+    isNormalUser = true;
+    extraGroups = [ "wheel" ];
+    openssh.authorizedKeys.keys = (
+      lib.flatten (
+        builtins.map utils.githubSSHKeys [
+          "alevy"
+          "lschuermann"
+          "leochanj105"
+        ]
+      )
+    ) ++ [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIBrOyN+OmWSv0/RYd7jK+TKx4tMO5Fuz8wyaMUR+j6A noise-eval-peer-key"
+    ];
+  };
 }

--- a/machines/sns51.nix
+++ b/machines/sns51.nix
@@ -24,4 +24,20 @@ in {
     extraGroups = [ "wheel" "kvm" ];
     openssh.authorizedKeys.keys = utils.githubSSHKeys "theanoli";
   };
+
+  users.users.noiseeval = {
+    isNormalUser = true;
+    extraGroups = [ "wheel" ];
+    openssh.authorizedKeys.keys = (
+      lib.flatten (
+        builtins.map utils.githubSSHKeys [
+          "alevy"
+          "lschuermann"
+          "leochanj105"
+        ]
+      )
+    ) ++ [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIBrOyN+OmWSv0/RYd7jK+TKx4tMO5Fuz8wyaMUR+j6A noise-eval-peer-key"
+    ];
+  };
 }

--- a/machines/sns52.nix
+++ b/machines/sns52.nix
@@ -38,5 +38,20 @@ in {
     extraGroups = [ "wheel" "kvm" "docker"];
     openssh.authorizedKeys.keys = utils.githubSSHKeys "ruipeterpan";
   };
-  
+
+  users.users.noiseeval = {
+    isNormalUser = true;
+    extraGroups = [ "wheel" ];
+    openssh.authorizedKeys.keys = (
+      lib.flatten (
+        builtins.map utils.githubSSHKeys [
+          "alevy"
+          "lschuermann"
+          "leochanj105"
+        ]
+      )
+    ) ++ [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIBrOyN+OmWSv0/RYd7jK+TKx4tMO5Fuz8wyaMUR+j6A noise-eval-peer-key"
+    ];
+  };
 }

--- a/machines/sns57.nix
+++ b/machines/sns57.nix
@@ -28,4 +28,20 @@ in {
     extraGroups = [ "wheel" "kvm" ];	
     openssh.authorizedKeys.keys = utils.githubSSHKeys "theanoli";
   };
+
+  users.users.noiseeval = {
+    isNormalUser = true;
+    extraGroups = [ "wheel" ];
+    openssh.authorizedKeys.keys = (
+      lib.flatten (
+        builtins.map utils.githubSSHKeys [
+          "alevy"
+          "lschuermann"
+          "leochanj105"
+        ]
+      )
+    ) ++ [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIBrOyN+OmWSv0/RYd7jK+TKx4tMO5Fuz8wyaMUR+j6A noise-eval-peer-key"
+    ];
+  };
 }

--- a/machines/sns59.nix
+++ b/machines/sns59.nix
@@ -71,4 +71,20 @@ in {
     extraGroups = [ "wheel" "kvm" ];
     openssh.authorizedKeys.keys = utils.githubSSHKeys "nataliepopescu";
   };
+
+  users.users.noiseeval = {
+    isNormalUser = true;
+    extraGroups = [ "wheel" ];
+    openssh.authorizedKeys.keys = (
+      lib.flatten (
+        builtins.map utils.githubSSHKeys [
+          "alevy"
+          "lschuermann"
+          "leochanj105"
+        ]
+      )
+    ) ++ [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIBrOyN+OmWSv0/RYd7jK+TKx4tMO5Fuz8wyaMUR+j6A noise-eval-peer-key"
+    ];
+  };
 }

--- a/machines/sns60.nix
+++ b/machines/sns60.nix
@@ -44,4 +44,20 @@ in {
     extraGroups = [ "wheel" "kvm" ];
     openssh.authorizedKeys.keys = utils.githubSSHKeys "nataliepopescu";
   };
+
+  users.users.noiseeval = {
+    isNormalUser = true;
+    extraGroups = [ "wheel" ];
+    openssh.authorizedKeys.keys = (
+      lib.flatten (
+        builtins.map utils.githubSSHKeys [
+          "alevy"
+          "lschuermann"
+          "leochanj105"
+        ]
+      )
+    ) ++ [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIBrOyN+OmWSv0/RYd7jK+TKx4tMO5Fuz8wyaMUR+j6A noise-eval-peer-key"
+    ];
+  };
 }

--- a/machines/sns61.nix
+++ b/machines/sns61.nix
@@ -44,4 +44,20 @@ in {
     extraGroups = [ "wheel" "kvm" ];
     openssh.authorizedKeys.keys = utils.githubSSHKeys "nataliepopescu";
   };
+
+  users.users.noiseeval = {
+    isNormalUser = true;
+    extraGroups = [ "wheel" ];
+    openssh.authorizedKeys.keys = (
+      lib.flatten (
+        builtins.map utils.githubSSHKeys [
+          "alevy"
+          "lschuermann"
+          "leochanj105"
+        ]
+      )
+    ) ++ [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIBrOyN+OmWSv0/RYd7jK+TKx4tMO5Fuz8wyaMUR+j6A noise-eval-peer-key"
+    ];
+  };
 }

--- a/machines/sns62.nix
+++ b/machines/sns62.nix
@@ -40,4 +40,20 @@ in {
   users.users.root.openssh.authorizedKeys.keys = [
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOD4XspKe2E5BhBmx+GtRHdRR72+Q7wC7nFHbDj1VVzJ lschuermann/silicon/sns-nixbuild"
   ];
+
+  users.users.noiseeval = {
+    isNormalUser = true;
+    extraGroups = [ "wheel" ];
+    openssh.authorizedKeys.keys = (
+      lib.flatten (
+        builtins.map utils.githubSSHKeys [
+          "alevy"
+          "lschuermann"
+          "leochanj105"
+        ]
+      )
+    ) ++ [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIBrOyN+OmWSv0/RYd7jK+TKx4tMO5Fuz8wyaMUR+j6A noise-eval-peer-key"
+    ];
+  };
 }


### PR DESCRIPTION
This adds a user to perform Noise evaluation on all SNS machines. We will likely refrain from using most of them, however this allows us to quickly add more machines in case we require them as clients. In general, we are going to check on the machines whether other users are running tasks concurrently and will clarify whether we can use the machines. We will try to primarily stick to SNS59-62 and use SNS62 as the server machine.