### PR TITLE
Add Noise eval user to SNS59-62 machines temporarily

### DIFF
--- a/machines/sns59.nix
+++ b/machines/sns59.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ config, pkgs, lib, ... }:
 
 let
   hostname = "sns59";
@@ -70,5 +70,21 @@ in {
     isNormalUser = true;
     extraGroups = [ "wheel" "kvm" ];
     openssh.authorizedKeys.keys = utils.githubSSHKeys "nataliepopescu";
+  };
+
+  users.users.noiseeval = {
+    isNormalUser = true;
+    extraGroups = [ "wheel" ];
+    openssh.authorizedKeys.keys = (
+      lib.flatten (
+        builtins.map utils.githubSSHKeys [
+          "alevy"
+          "lschuermann"
+          "leochanj105"
+        ]
+      )
+    ) ++ [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIBrOyN+OmWSv0/RYd7jK+TKx4tMO5Fuz8wyaMUR+j6A noise-eval-peer-key"
+    ];
   };
 }

--- a/machines/sns60.nix
+++ b/machines/sns60.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ config, pkgs, lib, ... }:
 
 let
   hostname = "sns60";
@@ -43,5 +43,21 @@ in {
     isNormalUser = true;
     extraGroups = [ "wheel" "kvm" ];
     openssh.authorizedKeys.keys = utils.githubSSHKeys "nataliepopescu";
+  };
+
+  users.users.noiseeval = {
+    isNormalUser = true;
+    extraGroups = [ "wheel" ];
+    openssh.authorizedKeys.keys = (
+      lib.flatten (
+        builtins.map utils.githubSSHKeys [
+          "alevy"
+          "lschuermann"
+          "leochanj105"
+        ]
+      )
+    ) ++ [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIBrOyN+OmWSv0/RYd7jK+TKx4tMO5Fuz8wyaMUR+j6A noise-eval-peer-key"
+    ];
   };
 }

--- a/machines/sns61.nix
+++ b/machines/sns61.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ config, pkgs, lib, ... }:
 
 let
   hostname = "sns61";
@@ -43,5 +43,21 @@ in {
     isNormalUser = true;
     extraGroups = [ "wheel" "kvm" ];
     openssh.authorizedKeys.keys = utils.githubSSHKeys "nataliepopescu";
+  };
+
+  users.users.noiseeval = {
+    isNormalUser = true;
+    extraGroups = [ "wheel" ];
+    openssh.authorizedKeys.keys = (
+      lib.flatten (
+        builtins.map utils.githubSSHKeys [
+          "alevy"
+          "lschuermann"
+          "leochanj105"
+        ]
+      )
+    ) ++ [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIBrOyN+OmWSv0/RYd7jK+TKx4tMO5Fuz8wyaMUR+j6A noise-eval-peer-key"
+    ];
   };
 }

--- a/machines/sns62.nix
+++ b/machines/sns62.nix
@@ -7,7 +7,7 @@
 # Vivado package needs to be added to the Nix store as documented in
 # "Adding files to the store" of https://nixos.wiki/wiki/Cheatsheet.
 
-{ config, pkgs, ... }:
+{ config, pkgs, lib, ... }:
 
 let
   hostname = "sns62";
@@ -40,4 +40,20 @@ in {
   users.users.root.openssh.authorizedKeys.keys = [
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOD4XspKe2E5BhBmx+GtRHdRR72+Q7wC7nFHbDj1VVzJ lschuermann/silicon/sns-nixbuild"
   ];
+
+  users.users.noiseeval = {
+    isNormalUser = true;
+    extraGroups = [ "wheel" ];
+    openssh.authorizedKeys.keys = (
+      lib.flatten (
+        builtins.map utils.githubSSHKeys [
+          "alevy"
+          "lschuermann"
+          "leochanj105"
+        ]
+      )
+    ) ++ [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIBrOyN+OmWSv0/RYd7jK+TKx4tMO5Fuz8wyaMUR+j6A noise-eval-peer-key"
+    ];
+  };
 }


### PR DESCRIPTION
This adds a user to perform Noise evaluation on SNS59-62 machines.