### PR TITLE
Add initial user assignment for SNS4, to be nix-litex CI machine

### DIFF
--- a/machines/sns4.nix
+++ b/machines/sns4.nix
@@ -1,0 +1,27 @@
+# Workstation to be used as a Hydra build machine for nix-litex:
+# https://git.sr.ht/~lschuermann/nix-litex
+
+{ config, pkgs, ... }:
+
+let
+  hostname = "sns4";
+  common = (import ./common.nix) { hostname = hostname; };
+  utils = import ../utils;
+in {
+
+  # Import common configuration for all machines (locale, SSHd, updates...)
+  imports = [ common ];
+
+  # List packages installed in system profile. To search, run:
+  # $ nix search wget
+  environment.systemPackages = with pkgs; [
+    wget vim htop tmux nload iftop dnsutils gitAndTools.gitFull gnupg
+    mtr bc zip unzip nmap nix-prefetch-git
+  ];
+
+  users.users.leons = {
+    isNormalUser = true;
+    extraGroups = [ "wheel" ];
+    openssh.authorizedKeys.keys = utils.githubSSHKeys "lschuermann";
+  };
+}


### PR DESCRIPTION
This is an initial assignment and configuration to be able to use the SNS4 (one of the old alpha machines) as a build machine for the nix-litex package set project. It only adds some packages and assigns a user, to be able to prototype the machine's configuration locally. Once finalized, the configuration can then be upstreamed here.